### PR TITLE
Custom hook dependencies with auto()

### DIFF
--- a/src/hooks.macro.js
+++ b/src/hooks.macro.js
@@ -282,6 +282,78 @@ function hookCreateTransform(parentPath, createPath, importedHookName, babel) {
   );
 }
 
+function collectIdentifierNodesInFunction(functionExpressionPath, babel) {
+  const { types: t } = babel;
+  const result = [];
+
+  const parentScope = reachSignificantScope(
+    t,
+    functionExpressionPath.parentPath.scope,
+  );
+
+  functionExpressionPath.traverse({
+    Expression(path) {
+      if (!t.isIdentifier(path)) {
+        return;
+      }
+
+      const binding = path.scope.getBinding(path.node.name);
+
+      // Reference without a binding (such as globals) are excluded
+      if (binding == null) {
+        return;
+      }
+
+      // Excluding bindings outside of the component
+      if (reachSignificantScope(t, binding.scope) !== parentScope) {
+        return;
+      }
+
+      result.push(path.node);
+    },
+  });
+
+  return result;
+}
+
+function autoRetrieveReferences(ownPath, functionCallPath, state, babel) {
+  const { types: t } = babel;
+  const references = [];
+
+  functionCallPath.parentPath.traverse({
+    Expression(path) {
+      if (!t.isFunctionExpression(path) && !t.isArrowFunctionExpression(path)) {
+        return;
+      }
+
+      references.push(...collectIdentifierNodesInFunction(path, babel));
+    },
+  });
+
+  const includedNames = {};
+
+  return references.filter(node => {
+    if (includedNames[node.name]) return false;
+    includedNames[node.name] = true;
+    return true;
+  });
+}
+
+function visitAutoReferences(entryPath, babel, visitor) {
+  const { types: t } = babel;
+
+  entryPath.traverse({
+    Expression(path) {
+      if (!t.isIdentifier(path)) {
+        return;
+      }
+
+      // All other bindings are included
+      visitor(path);
+    },
+  });
+}
+
 function hookTransform(path, state, macroName, hookName, autoClosure, babel) {
   const { types: t } = babel;
 
@@ -309,38 +381,65 @@ function hookTransform(path, state, macroName, hookName, autoClosure, babel) {
   }
 }
 
+function autoTransform(path, state, macroName, hook, autoClosure, babel) {
+  const { types: t } = babel;
+
+  const functionCallPath = path.parentPath;
+
+  const argument = functionCallPath.get('arguments.0');
+
+  if (argument) {
+    throw state.file.buildCodeFrameError(
+      (argument && argument.node) || path.node,
+      `${macroName} does not accept any arguments`,
+    );
+  }
+
+  const references = autoRetrieveReferences(
+    path,
+    functionCallPath,
+    state,
+    babel,
+  );
+
+  functionCallPath.replaceWith(t.arrayExpression(references));
+}
+
 const CONFIGS = [
-  ['useAutoMemo', 'useMemo', true],
-  ['useAutoCallback', 'useCallback', false],
-  ['useAutoEffect', 'useEffect', false],
-  ['useAutoLayoutEffect', 'useLayoutEffect', false],
+  ['useAutoMemo', 'useMemo', true, hookTransform],
+  ['useAutoCallback', 'useCallback', false, hookTransform],
+  ['useAutoEffect', 'useEffect', false, hookTransform],
+  ['useAutoLayoutEffect', 'useLayoutEffect', false, hookTransform],
+  ['auto', null, false, autoTransform],
 ];
 
 function memoMacro({ references, state, babel }) {
   const { types: t } = babel;
 
-  CONFIGS.forEach(({ 0: macroName, 1: hookName, 2: autoClosure }) => {
-    if (references[macroName]) {
-      references[macroName].forEach(referencePath => {
-        if (
-          t.isCallExpression(referencePath.parentPath) &&
-          referencePath.parentPath.node.callee === referencePath.node
-        ) {
-          hookTransform(
-            referencePath,
-            state,
-            macroName,
-            hookName,
-            autoClosure,
-            babel,
-          );
-        } else {
-          throw state.file.buildCodeFrameError(
-            referencePath.node,
-            `${macroName} can only be used a function, and can not be passed around as an argument.`,
-          );
-        }
-      });
-    }
-  });
+  CONFIGS.forEach(
+    ({ 0: macroName, 1: hookName, 2: autoClosure, 3: transform }) => {
+      if (references[macroName]) {
+        references[macroName].forEach(referencePath => {
+          if (
+            t.isCallExpression(referencePath.parentPath) &&
+            referencePath.parentPath.node.callee === referencePath.node
+          ) {
+            transform(
+              referencePath,
+              state,
+              macroName,
+              hookName,
+              autoClosure,
+              babel,
+            );
+          } else {
+            throw state.file.buildCodeFrameError(
+              referencePath.node,
+              `${macroName} can only be used a function, and can not be passed around as an argument.`,
+            );
+          }
+        });
+      }
+    },
+  );
 }

--- a/src/hooks.spec.js
+++ b/src/hooks.spec.js
@@ -107,38 +107,6 @@ pluginTester({
       }),
     ),
     {
-      title: 'auto() with multiple references',
-      error: false,
-      snapshot: false,
-      code: `
-      import { auto } from './hooks.macro'
-
-      function FakeComponent() {
-        const foo = Math.random()
-
-        useCustomHook(() => {
-          console.log(foo, foo)
-        }, auto())
-      }
-      `,
-    },
-    {
-      title: 'auto injects the dependencies',
-      error: false,
-      snapshot: false,
-      code: `
-      import { auto } from './hooks.macro'
-
-      function FakeComponent() {
-        const foo = Math.random()
-
-        useCustomHook(function () {
-          console.log(foo, foo)
-        }, auto())
-      }
-      `,
-    },
-    {
       title: 'Works with null',
       code: `
         import { useAutoMemo } from './hooks.macro'
@@ -784,6 +752,57 @@ pluginTester({
             console.log(id)
           });
         }
+      `,
+    },
+    {
+      title: 'auto() with multiple references and ArrowFunctionExpression',
+      error: false,
+      snapshot: false,
+      code: `
+      import { auto } from './hooks.macro'
+
+      function FakeComponent() {
+        const foo = 'foo'.toUpperCase()
+
+        useCustomHook(() => {
+          console.log(foo, foo)
+        }, auto())
+      }
+      `,
+      output: `
+      function FakeComponent() {
+        const foo = 'foo'.toUpperCase();
+        useCustomHook(() => {
+          console.log(foo, foo);
+        }, [foo]);
+      }
+      `,
+    },
+    {
+      title: 'auto() with FunctionExpression',
+      error: false,
+      snapshot: false,
+      code: `
+      import { auto } from './hooks.macro'
+
+      function FakeComponent() {
+        const foo = 'foo'.toUpperCase()
+
+        useCustomHook(function () {
+          console.log(foo)
+        }, auto())
+      }
+      `,
+      output: `
+      function FakeComponent() {
+        const foo = 'foo'.toUpperCase();
+        useCustomHook(
+          function () {
+            console.log(foo);
+          },
+          [foo],
+        );
+      }
       `,
     },
   ]),

--- a/src/hooks.spec.js
+++ b/src/hooks.spec.js
@@ -107,6 +107,38 @@ pluginTester({
       }),
     ),
     {
+      title: 'auto() with multiple references',
+      error: false,
+      snapshot: false,
+      code: `
+      import { auto } from './hooks.macro'
+
+      function FakeComponent() {
+        const foo = Math.random()
+
+        useCustomHook(() => {
+          console.log(foo, foo)
+        }, auto())
+      }
+      `,
+    },
+    {
+      title: 'auto injects the dependencies',
+      error: false,
+      snapshot: false,
+      code: `
+      import { auto } from './hooks.macro'
+
+      function FakeComponent() {
+        const foo = Math.random()
+
+        useCustomHook(function () {
+          console.log(foo, foo)
+        }, auto())
+      }
+      `,
+    },
+    {
       title: 'Works with null',
       code: `
         import { useAutoMemo } from './hooks.macro'


### PR DESCRIPTION
I wrote a basic version of `auto()`. It can be used like this:

```javascript
import { auto } from 'hooks.macro'

function MyComponent() {
  useSomeMacro(() => {
    console.log(foo)
  }, auto())
}
```

turns into

```javascript
```javascript
import { auto } from 'hooks.macro'

function MyComponent() {
  useSomeMacro(() => {
    console.log(foo)
  }, [foo])
}
```

I used inline snapshot output to avoid wrestling with Jest. Will update that later.

What do you think?